### PR TITLE
Remove reflection from all namespaces (34% faster)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,8 @@
                  [crypto-equality "1.0.0"]
                  [commons-codec/commons-codec "1.10"]]
   :profiles {:dev {:dependencies [[speclj "3.3.2"]
-                                  [org.bouncycastle/bcpkix-jdk15on "1.56"]]}}
+                                  [org.bouncycastle/bcpkix-jdk15on "1.56"]]
+                   :global-vars {*warn-on-reflection* true}}}
   :repositories [["releases" {:url "https://clojars.org/repo"
                               :sign-releases false }]]
   :plugins [[speclj "3.3.2"]]

--- a/src/jerks_whistling_tunes/utils.clj
+++ b/src/jerks_whistling_tunes/utils.clj
@@ -1,14 +1,14 @@
 (ns jerks-whistling-tunes.utils
   (:import org.apache.commons.codec.binary.Base64))
 
-(def ^:private base-64-encoder (Base64. -1 (.getBytes "") true))
+(def ^:private ^Base64 base-64-encoder (Base64. -1 (.getBytes "") true))
 
 (defn decode-base-64
   "Returns the decoded base 64 url safe encoded string."
-  [str]
-  (.decode base-64-encoder str))
+  [s]
+  (.decode base-64-encoder s))
 
 (defn encode-base-64
   "Returns a base 64 url safe encoded representation of the string"
-  [bytes]
-  (String. (.encode base-64-encoder bytes) "UTF-8"))
+  [^bytes bs]
+  (String. (.encode base-64-encoder bs) "UTF-8"))


### PR DESCRIPTION
Before

```text
Evaluation count : 7374 in 6 samples of 1229 calls.
             Execution time mean : 80.742711 µs
    Execution time std-deviation : 570.797426 ns
   Execution time lower quantile : 80.096170 µs ( 2.5%)
   Execution time upper quantile : 81.605858 µs (97.5%)
                   Overhead used : 6.696816 ns
```

After

```text
Evaluation count : 11454 in 6 samples of 1909 calls.
             Execution time mean : 53.017780 µs
    Execution time std-deviation : 665.405999 ns
   Execution time lower quantile : 52.061622 µs ( 2.5%)
   Execution time upper quantile : 53.609765 µs (97.5%)
                   Overhead used : 6.763715 ns
```

Using criterium and the following session (I've replaced the actual values with fillers, to hide necessary info -- the validation was successful though):

```clojure
user=> (use 'jerks-whistling-tunes.core)
nil
user=> (use 'jerks-whistling-tunes.sign)
nil
user=> (use 'jerks-whistling-tunes.utils)
nil
user=> (use 'criterium.core)
nil
user=> (quick-bench (validate "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY.ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ" (-> "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC" hs256 signature) (aud "DDDD") exp))
```